### PR TITLE
Upload release APK to artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,3 +27,9 @@ jobs:
       run: ./gradlew build
     - name: Spotless Check
       run: ./gradlew spotlessCheck
+    - name: Update Release APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: release-apk
+        path: ./app/build/outputs/apk/release/app-release-unsigned.apk
+        if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ The `BoringdroidSettings` is released with apk, and you can use the following co
 
 And copy the `app/build/outputs/apk/release/app-release-unsigned.apk` as the released apk to the 
 release repository.
+
+Also, we can download latest build APK from GitHub Action's artifacts.


### PR DESCRIPTION
It's the first step to easy the process of updating prebuilt Settings APK to boringdroid source tree.