### PR TITLE
Use pure version number for Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 	implementation 'androidx.appcompat:appcompat:1.6.1'
 	implementation "androidx.core:core-ktx:1.10.1"
 	implementation "androidx.preference:preference-ktx:1.2.0"
-	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22"
 	testImplementation 'junit:junit:4.13.2'
 	androidTestImplementation 'androidx.test:runner:1.5.2'
 	androidTestImplementation 'androidx.test:rules:1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.8.22'
     repositories {
         mavenCentral()
         google()
@@ -8,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22"
     }
 }
 


### PR DESCRIPTION
This project is simple, and we can use dependabot to help us upgrade dependencies.